### PR TITLE
Fix cors bug: explicitly give origin to allow frontend access

### DIFF
--- a/mern/server/index.js
+++ b/mern/server/index.js
@@ -6,11 +6,15 @@ const authRoutes = require('./routes/auth');
 const clubRoutes = require('./routes/clubs'); 
 require("dotenv").config();
 
+const corsOptions = {
+    origin: "http://localhost:5173", 
+    credentials: true, 
+};
 const app = express();
+
 app.use(express.json());
 app.use(cookieParser());
-app.use(cors());
-
+app.use(cors(corsOptions));
 app.use('/auth', authRoutes);
 app.use('/clubs', clubRoutes);
 


### PR DESCRIPTION
Since axios.defaults.withCredentials = true, we must explicitly allow frontend at port 5173 to make requests to port 3001. Error before was from this.