### PR TITLE
Handle blank/no reviews for club cards and reviews

### DIFF
--- a/mern/client/src/components/Club.jsx
+++ b/mern/client/src/components/Club.jsx
@@ -101,8 +101,8 @@ function Club() {
 
     //update application status based on highest number of responses
     application = applicationCount[0] > applicationCount[1] ? "Yes" : "No";
-    overallRating = length != 0 ? ((overallRating/length).toFixed(1)) : overallRating.toFixed(1);
-    timeCommitment = Math.floor(timeCommitment / length);
+    overallRating = length ? ((overallRating/length).toFixed(1)) : overallRating.toFixed(1);
+    timeCommitment = length !== 0 ? Math.floor(timeCommitment / length) : -1;
 
     let maxCount = 0;
     for(let [key, value] of majorCounts) {

--- a/mern/client/src/components/ClubInfoCard.jsx
+++ b/mern/client/src/components/ClubInfoCard.jsx
@@ -38,10 +38,10 @@ function ClubInfoCard({title, description, tags, major, rating, time, applicatio
                         <span key={index}>{tag}{index < tags.length - 1 && ', '}</span>
                     ))}
                     <br/>
-                    <strong>Most common major:</strong> {major}
+                    <strong>Most common major:</strong> {major !== "" ? major : "N/A"}
                     <br/>
                     
-                    <strong>Time commitment:</strong> ~{time} hours/week
+                    <strong>Time commitment:</strong> {time !== -1 ? `~${time} hours/week` : "N/A"}
                     <br/>
                     
                     <strong>Application Required?:</strong> {application}

--- a/mern/client/src/components/ReviewCard.jsx
+++ b/mern/client/src/components/ReviewCard.jsx
@@ -29,7 +29,7 @@ function ReviewCard({description, major, application, time, position, rating, da
                         <br/>
                         Time commitment: {time} hour{time === '1' ? '' : 's'}/week
                         <br/>
-                        Position: {position}
+                        Position: {position !== "" ? position : "N/A"}
                     </p>
                     <Rating value={rating.toFixed(1)}/>
                 </div>


### PR DESCRIPTION
Handle when there are no reviews for a club (NaN values/empty) and when optional fields (position) are left blank on reviews.

**To test:** 
1. Please check that the values for a club correctly reflect what is expected (depending on if a club has been reviewed or not), and that 
2. Reviews with the position field left blank display Position: N/A rather than just Position: 